### PR TITLE
Indentation

### DIFF
--- a/swift-mode.el
+++ b/swift-mode.el
@@ -166,7 +166,7 @@ class Foo:
 (defvar swift-smie--operators-regexp "\\`[-.!#$%&=^~\\|@+:*<>?]+\\'")
 
 (defun swift-smie--implicit-semi-p ()
-  "returns t if the cursor is at the end of a statement"
+  "Return t if the cursor is at the end of a statement."
   (save-excursion
     (or
      ;; inserts implicit semicolon just after a ">" token of a type parameter
@@ -211,7 +211,7 @@ class Foo:
              (member (smie-default-forward-token) '("as" "is"))))))))
 
 (defun swift-smie--is-type-colon ()
-  "returns t if a colon at the cursor is the colon for supertype declaration or type declaration of let or var."
+  "Return t if a colon at the cursor is the colon for supertype declaration or type declaration of let or var."
   (save-excursion
     (or (equal (smie-default-backward-token) ">")
         (member (smie-default-backward-token) '("class" "let" "var")))))
@@ -328,7 +328,7 @@ class Foo:
                                          &optional
                                          stop-at-bol-parent-tokens
                                          stop-at-bol-self-tokens)
-  "backwards sexps until one of given tokens.
+  "Backward sexps until one of given tokens.
 When this function returns, the cursor is at just after one of given tokens.
 The form of return values are same as one of `smie-backward-sexp`.
 
@@ -371,17 +371,16 @@ Typically, this is a list of list element starter tokens (e.g. 'case' of switch 
     parent))
 
 (defun swift-smie--align-with (parent &optional offset)
-  "aligns with given parent token with optional offset."
+  "Align with given parent token with optional offset."
   (save-excursion
     (goto-char (nth 1 parent))
     (cons 'column (+ (or offset 0) (smie-indent-virtual)))))
 
 (defun swift-smie--indent-keyword (parents &optional offset)
-  "indents based on outer open-paren or previous statement/declaration.
+  "Indent based on outer open-paren or previous statement/declaration.
 
 PARENTS is a list of parent tokens (i.e. open-paren or statement separator).
-OFFSET is a offset from parent tokens, or 0 if omitted.
-"
+OFFSET is a offset from parent tokens, or 0 if omitted."
   (save-excursion
     (let* ((pos (point))
            (parent (swift-smie--backward-sexps-until parents)))
@@ -391,11 +390,11 @@ OFFSET is a offset from parent tokens, or 0 if omitted.
 
 (defvar swift-smie--statement-parent-tokens
   '("IMP;" ";" "{" "(" "[")
-  "parent tokens for statements")
+  "Parent tokens for statements.")
 
 (defvar swift-smie--expression-parent-tokens
   (append swift-smie--statement-parent-tokens '("," "<T"))
-  "parent tokens for expressions")
+  "Parent tokens for expressions.")
 
 (defun swift-smie-rules (kind token)
   (pcase (cons kind token)
@@ -553,8 +552,8 @@ OFFSET is a offset from parent tokens, or 0 if omitted.
     ))
 
 (defun swift-smie--backward-for-head ()
-  "backwards the head of a for-statement (i.e. 'for foo; bar; buz') and returns
-the column of the \"for\" token.
+  "Backward the head of a for-statement (i.e. 'for foo; bar; buz') and
+returns the column of the \"for\" token.
 If the cursor is not at a head of a for-statement, keeps cursor position as is
 and returns nil"
   (save-excursion
@@ -575,22 +574,22 @@ and returns nil"
             (current-column)))))))
 
 (defun swift-smie--rule-for ()
-  "special rule for 'for' statement"
+  "Special rule for 'for' statement."
   (let ((column (swift-smie--backward-for-head)))
     (when column (cons 'column column))))
 
 (defun swift-smie--op-parent-tokens (&optional ignore-question)
-  "returns parent tokens for operators"
+  "Return parent tokens for operators."
   (append swift-smie--expression-parent-tokens
           (list "=" (if ignore-question ":" "?") ":")))
 
 (defun swift-smie--goto-op-parent (&optional ignore-question)
-  "goes to the parent of the current operator token"
+  "Go to the parent of the current operator token."
   (swift-smie--backward-sexps-until
    (swift-smie--op-parent-tokens ignore-question)))
 
 (defun swift-smie--op-offset (parent &optional ignore-question offset)
-  "returns the offset after operator tokens"
+  "Return the offset after operator tokens."
   (- (or offset swift-indent-multiline-statement-offset)
      ;; Special handling for assignment and conditional operators:
      ;;

--- a/swift-mode.el
+++ b/swift-mode.el
@@ -402,7 +402,7 @@ OFFSET is a offset from parent tokens, or 0 if omitted."
   "Parent tokens for statements.")
 
 (defvar swift-smie--expression-parent-tokens
-  (append swift-smie--statement-parent-tokens '("," "<T"))
+  (append swift-smie--statement-parent-tokens '("," "<T" "for"))
   "Parent tokens for expressions.")
 
 (defun swift-smie-rules (kind token)

--- a/swift-mode.el
+++ b/swift-mode.el
@@ -195,9 +195,9 @@ class Foo:
            (save-excursion
              (goto-char (line-beginning-position))
              (< (line-end-position) (progn (forward-comment (point-max)) (point))))
-           ;; supresses implicit semicolon after operator or keyword
-           (looking-back "[-.({[,!#$%&=^~\\|@+:*<>?]" (- (point) 1) t)
            ;; supresses implicit semicolon after operator
+           (looking-back "[-.({[,!#$%&=^~\\|@+:*<>?]" (- (point) 1) t)
+           ;; supresses implicit semicolon after keyword
            ;; Note that "as?" is already handled by preceeding conditions.
            (save-excursion
              (member (smie-default-backward-token) '("as" "is" "class" "deinit" "enum" "extension" "func" "import" "init" "internal" "let" "operator" "private" "protocol" "public" "static" "struct" "subscript" "typealias" "var" "case" "for" "if" "switch" "where" "while" "associativity" "convenience" "dynamic" "didSet" "final" "get" "infix" "inout" "lazy" "mutating" "nonmutating" "optional" "override" "postfix" "precedence" "prefix" "required" "set" "unowned" "weak" "willSet")))
@@ -205,7 +205,7 @@ class Foo:
            (progn
              (forward-comment (point-max))
              (looking-at "[-.{,!#$%&=^~\\|+:*<>?]"))
-           ;; supresses implicit semicolon before operator
+           ;; supresses implicit semicolon before keyword
            (save-excursion
              ;; note that comments are already skipped by previous condition
              (member (smie-default-forward-token) '("as" "is"))))))))

--- a/swift-mode.el
+++ b/swift-mode.el
@@ -245,10 +245,12 @@ class Foo:
       "T>")
 
      (t (let
-            ((tok (smie-default-forward-token)))
+            ((pos-after-comment (point))
+             (tok (smie-default-forward-token)))
           (cond
-           ((equal tok ">:") ; e.g. class Foo<A>:
-            (backward-char 1)
+           ((string-match-p ">+:" tok) ; e.g. class Foo<A: B<C>>:
+            (goto-char pos-after-comment)
+            (forward-char 1)
             ">")
            ((equal tok ":")
             (save-excursion
@@ -300,10 +302,12 @@ class Foo:
       "T>")
 
      (t (let
-            ((tok (smie-default-backward-token)))
+            ((pos-before-comment (point))
+             (tok (smie-default-backward-token)))
           (cond
-           ((equal tok ">:") ; e.g. class Foo<A>:
-            (forward-char 1)
+           ((string-match-p ">+:" tok) ; e.g. class Foo<A: B<C>>:
+            (goto-char pos-before-comment)
+            (backward-char 1)
             "TYPE:")
            ((equal tok ":")
             (if (swift-smie--is-type-colon) "TYPE:" ":"))

--- a/test/indentation-tests.el
+++ b/test/indentation-tests.el
@@ -841,6 +841,38 @@ for
 }
 ")
 
+
+(check-indentation indents-for-statements/15
+  "
+for i
+|= 0;
+    i < 10;
+    i++ {
+}
+" "
+for i
+      |= 0;
+    i < 10;
+    i++ {
+}
+")
+
+(check-indentation indents-for-statements/16
+  "
+for i = 0,
+|j = 0;
+    i < 10;
+    i++ {
+}
+" "
+for i = 0,
+    |j = 0;
+    i < 10;
+    i++ {
+}
+")
+
+
 (check-indentation indents-after-for-statements/1
   "
 for

--- a/test/indentation-tests.el
+++ b/test/indentation-tests.el
@@ -149,6 +149,17 @@ x
 }
 ")
 
+(check-indentation block-inside-parenthesis/3
+  "
+\({
+|a
+})
+" "
+\({
+     |a
+})
+")
+
 (check-indentation indent-if-body
   "
 if true {
@@ -183,6 +194,52 @@ if true {
 if true {
 } else if false {
     |foo
+}
+")
+
+(check-indentation indent-long-if-else-if/1
+  "
+if a {
+    a
+} else if a {
+    a
+} else if a {
+    |a
+} else {
+    a
+}
+" "
+if a {
+    a
+} else if a {
+    a
+} else if a {
+    |a
+} else {
+    a
+}
+")
+
+(check-indentation indent-long-if-else-if/2
+  "
+if a {
+    a
+} else if a {
+    a
+} else if a {
+    a
+|} else {
+    a
+}
+" "
+if a {
+    a
+} else if a {
+    a
+} else if a {
+    a
+|} else {
+    a
 }
 ")
 
@@ -456,6 +513,32 @@ case foo where bar,
 ")
 
 
+(check-indentation indents-case-statements-after-case-label/1
+  "
+switch true {
+case
+|foo:
+    bar
+}
+" "
+switch true {
+case
+  |foo:
+    bar
+}
+")
+
+
+(check-indentation indents-case-statements-after-switch/1
+  "
+switch
+|foo
+" "
+switch
+  |foo
+")
+
+
 (check-indentation indents-case-statements-to-user-defined-offset/1
   "
 switch true {
@@ -639,6 +722,57 @@ class Foo: Foo, Bar,
 }
 ")
 
+(check-indentation indents-class-declaration/6
+                   "
+class Foo:
+|Foo, Bar, Baz {
+}
+" "
+class Foo:
+    |Foo, Bar, Baz {
+}
+")
+
+(check-indentation indents-class-declaration/7
+                   "
+class Foo: Bar<(A, B),
+|[C]>
+" "
+class Foo: Bar<(A, B),
+               |[C]>
+")
+
+(check-indentation indents-class-declaration/8
+                   "
+class Foo: Bar<A, B,
+|[C]>
+" "
+class Foo: Bar<A, B,
+               |[C]>
+")
+
+(check-indentation indents-public-class-declaration/1
+                   "
+public class Foo: Foo, Bar,
+|Baz {
+}
+" "
+public class Foo: Foo, Bar,
+    |Baz {
+}
+")
+
+(check-indentation indents-public-class-declaration/2
+  "
+public class Foo {
+          |foo
+}
+" "
+public class Foo {
+    |foo
+}
+")
+
 (check-indentation indents-func-declaration/1
   "
 func Foo(a: String) {
@@ -687,7 +821,7 @@ class Foo {
 }
 ")
 
-(check-indentation indents-func-declaration/2
+(check-indentation indents-func-declaration/5
                    "
 class func Foo() {
 |foo
@@ -695,6 +829,96 @@ class func Foo() {
 " "
 class func Foo() {
     |foo
+}
+")
+
+(check-indentation indents-func-declaration/6
+                   "
+func Foo(aaaaaaaaa:
+         |AAAAAAAAA) {
+}
+" "
+func Foo(aaaaaaaaa:
+           |AAAAAAAAA) {
+}
+")
+
+(check-indentation indents-func-declaration/7
+  "
+func foo() ->
+|Foo
+" "
+func foo() ->
+  |Foo
+")
+
+(check-indentation indents-func-declaration/8
+  "
+func foo() ->
+|(A, B)
+" "
+func foo() ->
+  |(A, B)
+")
+
+(check-indentation indents-func-declaration/9
+  "
+func foo() ->
+|[A]
+" "
+func foo() ->
+  |[A]
+")
+
+(check-indentation indents-protocol-declaration/1
+                   "
+protocol Foo {
+  func foo()
+|func bar()
+}
+" "
+protocol Foo {
+  func foo()
+  |func bar()
+}
+")
+
+(check-indentation indents-protocol-declaration/2
+                   "
+protocol Foo {
+  func foo() -> Foo
+|func bar() -> Bar
+}
+" "
+protocol Foo {
+  func foo() -> Foo
+  |func bar() -> Bar
+}
+")
+
+(check-indentation indents-protocol-declaration/3
+                   "
+protocol Foo {
+  func foo() -> Foo<A>
+|func bar() -> Bar<A>
+}
+" "
+protocol Foo {
+  func foo() -> Foo<A>
+  |func bar() -> Bar<A>
+}
+")
+
+(check-indentation indents-protocol-declaration/3
+                   "
+protocol Foo {
+  func foo() -> [A]
+|func bar() -> [A]
+}
+" "
+protocol Foo {
+  func foo() -> [A]
+  |func bar() -> [A]
 }
 ")
 
@@ -763,6 +987,64 @@ var result = Dictionary<String, V>()
 " "
 var result = Dictionary<String, V>()
 |foo
+")
+
+(check-indentation indents-declaration/8
+  "
+let foo =
+|bar
+" "
+let foo =
+  |bar
+")
+
+(check-indentation indents-declaration/9
+  "
+let foo: Foo? =
+|bar
+" "
+let foo: Foo? =
+  |bar
+")
+
+(check-indentation indents-declaration/10
+  "
+let foo: Foo<A> =
+|bar
+" "
+let foo: Foo<A> =
+  |bar
+")
+
+(check-indentation indents-declaration/11
+  "
+let foo = [
+    foo:
+|bar
+]
+" "
+let foo = [
+    foo:
+      |bar
+]
+")
+
+(check-indentation indents-declaration/12
+  "
+let foo = [
+|[
+" "
+let foo = [
+    |[
+")
+
+(check-indentation indents-declaration/12
+  "
+let foo = {
+|[
+" "
+let foo = {
+    |[
 ")
 
 (check-indentation indents-multiline-expressions/1
@@ -837,6 +1119,136 @@ let options = NSRegularExpressionOptions.CaseInsensitive &
 " "
 let options = NSRegularExpressionOptions.CaseInsensitive &
               |NSRegularExpressionOptions.DotMatchesLineSeparators
+")
+
+(check-indentation indents-multiline-expressions/9
+                   "
+foo?[bar] +
+|a
+" "
+foo?[bar] +
+  |a
+")
+
+(check-indentation indents-multiline-expressions/10
+                   "
+foo?(bar) +
+|a
+" "
+foo?(bar) +
+  |a
+")
+
+(check-indentation indents-multiline-expressions/11
+                   "
+func a () {
+    a +
+|a
+" "
+func a () {
+    a +
+      |a
+")
+
+(check-indentation indents-multiline-expressions/12
+                   "
+func a () {
+    a
+|.a()
+" "
+func a () {
+    a
+      |.a()
+")
+
+(check-indentation indents-multiline-expressions/13
+                   "
+if (a
+|.b)
+" "
+if (a
+      |.b)
+")
+
+(check-indentation indents-multiline-expressions/14
+                   "
+a ??
+|b
+" "
+a ??
+  |b
+")
+
+(check-indentation indents-multiline-expressions/15
+                   "
+a as
+|b
+" "
+a as
+  |b
+")
+
+(check-indentation indents-multiline-expressions/16
+                   "
+a as?
+|b
+" "
+a as?
+  |b
+")
+
+(check-indentation indents-multiline-expressions/17
+                   "
+a is
+|b
+" "
+a is
+  |b
+")
+
+(check-indentation indents-multiline-expressions/18
+                   "
+CGPoint(x: aaaaaaaaaaaaaaa.x +
+|bbbbbbbbbbbbbbbb,
+        y: aaaaaaaaaaaaaaa.y +
+           bbbbbbbbbbbbbbbb)
+" "
+CGPoint(x: aaaaaaaaaaaaaaa.x +
+           |bbbbbbbbbbbbbbbb,
+        y: aaaaaaaaaaaaaaa.y +
+           bbbbbbbbbbbbbbbb)
+")
+
+(check-indentation indents-long-parameters/1
+                   "
+func foo() {
+    timer = NSTimer.scheduledTimerWithTimeInterval(
+|1.0,
+      target: self,
+      selector: Selector(\"onTimer\"),
+      userInfo: nil,
+      repeats: true)
+}
+" "
+func foo() {
+    timer = NSTimer.scheduledTimerWithTimeInterval(
+      |1.0,
+      target: self,
+      selector: Selector(\"onTimer\"),
+      userInfo: nil,
+      repeats: true)
+}
+")
+
+(check-indentation indents-long-parameters/2
+                   "
+aaaaaa.aaaaaaaaaaaaaaaaaaaaa(
+  |aaaaaaaaaaaaaaaaaaaaa
+)
+" "
+aaaaaa.aaaaaaaaaaaaaaaaaaaaa(
+  |aaaaaaaaaaaaaaaaaaaaa
+)
 ")
 
 (check-indentation indents-multiline-expressions-to-user-defined-offset/1
@@ -930,6 +1342,116 @@ let foo = bar >
     |3
 "
 )
+
+
+(check-indentation anonymous-function-as-a-argument/1
+                   "
+UIView.animateWithDuration(1.0,
+                           animations: {
+|}
+" "
+UIView.animateWithDuration(1.0,
+                           animations: {
+                           |}
+")
+
+(check-indentation anonymous-function-as-a-argument/2
+                   "
+UIView.animateWithDuration(
+  1.0,
+  animations: {
+|}
+" "
+UIView.animateWithDuration(
+  1.0,
+  animations: {
+  |}
+")
+
+(check-indentation conditional-operator/1
+                   "
+let a = a
+        |? a +
+          1
+        : a +
+          1
+" "
+let a = a
+        |? a +
+          1
+        : a +
+          1
+")
+
+(check-indentation conditional-operator/2
+                   "
+let a = a
+        ? a +
+          |1
+        : a +
+          1
+" "
+let a = a
+        ? a +
+          |1
+        : a +
+          1
+")
+
+(check-indentation conditional-operator/3
+                   "
+let a = a
+        ? a +
+          1
+        |: a +
+          1
+" "
+let a = a
+        ? a +
+          1
+        |: a +
+          1
+")
+
+(check-indentation conditional-operator/4
+                   "
+let a = a
+        ? a +
+          1
+        : a +
+          |1
+" "
+let a = a
+        ? a +
+          1
+        : a +
+          |1
+")
+
+(check-indentation conditional-operator/5
+                   "
+let a = a ?
+|a : a
+" "
+let a = a ?
+        |a : a
+")
+
+(check-indentation blank-line/1
+                   "
+func foo() {
+    let a = 1
+
+|let b = 1
+}
+" "
+func foo() {
+    let a = 1
+
+    |let b = 1
+}
+")
+
 
 
 (provide 'indentation-tests)

--- a/test/indentation-tests.el
+++ b/test/indentation-tests.el
@@ -751,6 +751,15 @@ class Foo: Bar<A, B,
                |[C]>
 ")
 
+(check-indentation indents-class-declaration/9
+                   "
+class Foo<A: B<C>>:
+                   |Bar
+" "
+class Foo<A: B<C>>:
+    |Bar
+")
+
 (check-indentation indents-public-class-declaration/1
                    "
 public class Foo: Foo, Bar,

--- a/test/indentation-tests.el
+++ b/test/indentation-tests.el
@@ -645,6 +645,274 @@ for var index = 0; index < 3; ++index  {
 }
 ")
 
+(check-indentation indents-for-statements/4
+  "
+for
+  var index = 0;
+  index < 3;
+  ++index  {
+|foo
+}
+" "
+for
+  var index = 0;
+  index < 3;
+  ++index  {
+    |foo
+}
+")
+
+(check-indentation indents-for-statements/5
+  "
+for
+|var index = 0;
+  index < 3;
+  ++index  {
+    foo
+}
+" "
+for
+  |var index = 0;
+  index < 3;
+  ++index  {
+    foo
+}
+")
+
+(check-indentation indents-for-statements/5
+  "
+for
+  var index = 0;
+|index < 3;
+  ++index  {
+    foo
+}
+" "
+for
+  var index = 0;
+  |index < 3;
+  ++index  {
+    foo
+}
+")
+
+(check-indentation indents-for-statements/6
+  "
+for
+  var index = 0;
+  index < 3;
+|++index  {
+    foo
+}
+" "
+for
+  var index = 0;
+  index < 3;
+  |++index  {
+    foo
+}
+")
+
+(check-indentation indents-for-statements/7
+  "
+for
+  x
+  in
+  xs  {
+    |foo
+}
+" "
+for
+  x
+  in
+  xs  {
+    |foo
+}
+")
+
+(check-indentation indents-for-statements/8
+  "
+for
+|x
+  in
+  xs  {
+    foo
+}
+" "
+for
+  |x
+  in
+  xs  {
+    foo
+}
+")
+
+(check-indentation indents-for-statements/9
+  "
+for
+  x
+|in
+  xs  {
+    foo
+}
+" "
+for
+  x
+  |in
+  xs  {
+    foo
+}
+")
+
+(check-indentation indents-for-statements/10
+  "
+for
+  x
+  in
+|xs  {
+    foo
+}
+" "
+for
+  x
+  in
+  |xs  {
+    foo
+}
+")
+
+(check-indentation indents-for-statements/11
+  "
+for
+|x in
+  xs  {
+    foo
+}
+" "
+for
+  |x in
+  xs  {
+    foo
+}
+")
+
+(check-indentation indents-for-statements/12
+  "
+for
+  x in
+|xs  {
+    foo
+}
+" "
+for
+  x in
+  |xs  {
+    foo
+}
+")
+
+(check-indentation indents-for-statements/13
+  "
+for
+|x
+  in xs  {
+    foo
+}
+" "
+for
+  |x
+  in xs  {
+    foo
+}
+")
+
+(check-indentation indents-for-statements/14
+  "
+for
+  x
+|in xs  {
+    foo
+}
+" "
+for
+  x
+  |in xs  {
+    foo
+}
+")
+
+(check-indentation indents-after-for-statements/1
+  "
+for
+  var index = 0;
+  index < 3;
+  ++index  {
+    foo
+}
+  |foo()
+" "
+for
+  var index = 0;
+  index < 3;
+  ++index  {
+    foo
+}
+|foo()
+")
+
+(check-indentation indents-after-for-statements/2
+  "
+for
+  x
+  in
+  xs  {
+    foo
+}
+  |foo()
+" "
+for
+  x
+  in
+  xs  {
+    foo
+}
+|foo()
+")
+
+(check-indentation indents-after-for-statements/3
+  "
+for
+  x in
+  xs  {
+    foo
+}
+  |foo()
+" "
+for
+  x in
+  xs  {
+    foo
+}
+|foo()
+")
+
+(check-indentation indents-after-for-statements/4
+  "
+for
+  x
+  in xs  {
+    foo
+}
+  |foo()
+" "
+for
+  x
+  in xs  {
+    foo
+}
+|foo()
+")
+
 (check-indentation indents-while-statements
   "
 while foo < bar{
@@ -1459,6 +1727,15 @@ func foo() {
 
     |let b = 1
 }
+")
+
+(check-indentation after-return
+                   "
+return
+|1
+" "
+return
+  |1
 ")
 
 


### PR DESCRIPTION
This patch updates most of indentation logic.

The current implementation defines a complex syntax for SIME and depends on the indentation logic of SMIE. Unfortunately, SMIE is a black magic and controlling SMIE is very hard, so that results in a fragile and inconsistent logic:

```swift
func foo() {
    foo
  .bar() // :(
    foo
      .bar()
}
```

```swift
CGPoint(x: aaaaaaaaaaaaaaa.x +
         bbbbbbbbbbbbbbbb, // 1 space
        y: aaaaaaaaaaaaaaa.y +
          bbbbbbbbbbbbbbbb) // 2 spaces
```

```swift
class Foo: Bar,
    Baz { // 4 spaces from "class"
}

class Foo:
      Bar, Baz { // aligns with "Foo"
}
```

```swift
a
  .b // 2 spaces

if (a
     .b) { // 1 spaces
}
```

```swift
protocol Foo {
    func foo()
func bar() // :(
}
```

```swift
public class Foo {
           func foo() { // :(
} // :(
       } // :(
```

```swift
let a = [
[ // :(
    a
]
]
```

```swift
UIView.animateWithDuration(1.0,
                           animations: {
                               foo.center =
                               CGPoint(x: x, y: y) // :(
                              } // :(
                          )
```

```swift
protocol Foo {
    func foo() -> Foo<(A,
                       B),
[C]>  // :(
}
 ```

This patch defines a simple syntax enough for indentation and use a simple manual logic for most cases.

The new logic also supports different wrapping styles:

```swift
let x =
  1 +
  1 +
  1

let x
  = 1
    + 1
    + 1
```

```swift
timer = NSTimer.scheduledTimerWithTimeInterval(1.0,
                                               target: self,
                                               selector: Selector("onTimer"),
                                               userInfo: nil,
                                               repeats: true)

timer = NSTimer.scheduledTimerWithTimeInterval(
  1.0,
  target: self,
  selector: Selector("onTimer"),
  userInfo: nil,
  repeats: true
)
```

```swift
let x = [
    foo:
      bar,
    foo
      : bar
]
    
```

```swift
func a() ->
  [a] {
    a
}

func a()
  -> [a] {
    a
}
```

The new logic passes all existing tests and new tests (on Emacs 24.4.1).

Sorry for a huge monolithic patch.
