### PR TITLE
Test against 24.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,21 @@
 language: emacs-lisp
-env:
-  - EMACS=emacs24         PATH="$HOME/.cask/bin:$PATH"
 
-install:
-  - sudo add-apt-repository -y ppa:cassou/emacs
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq emacs24 emacs24-el
-  - sudo apt-get install texinfo
-  - curl -fsSkL https://raw.github.com/cask/cask/master/go | python
+env:
+  - EVM_EMACS=emacs-24.3-bin
+  - EVM_EMACS=emacs-24.4-bin
+
+before_install:
+  - sudo mkdir /usr/local/evm
+  - sudo chown travis:travis /usr/local/evm
+  - curl -fsSkL https://raw.github.com/rejeep/evm/master/go | bash
+  - export PATH="/home/travis/.evm/bin:$PATH"
+  - evm install $EVM_EMACS --skip --use
+  - curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
+  - export PATH="/home/travis/.cask/bin:$PATH"
+  - cask info
+  - cask install
+  - emacs --version
+  - cask --version
 
 script:
   - make

--- a/Cask
+++ b/Cask
@@ -1,4 +1,5 @@
 (source melpa)
+(source gnu)
 (source org)
 
 (package-file "swift-mode.el")

--- a/swift-mode.el
+++ b/swift-mode.el
@@ -281,14 +281,14 @@
     (`(:before . ".")
      (if (or (looking-at "[.][\n]")
              (smie-rule-bolp))
-         (smie-rule-parent swift-indent-multiline-statement-offset)))
+         swift-indent-multiline-statement-offset))
 
     ;; Apply swift-indent-multiline-statement-offset if
     ;; operator is the last symbol on the line
     (`(:before . "OP")
      (if (and (looking-at ".[\n]")
               (not (smie-rule-sibling-p)))
-         (smie-rule-parent swift-indent-multiline-statement-offset)))
+         swift-indent-multiline-statement-offset))
 
     ;; Indent second line of the multi-line class
     ;; definitions with swift-indent-offset


### PR DESCRIPTION
- Fixes issue with the current tests due to missing package
- Adds emacs 24.4 to the travis build matrix
- Fixes issues recovered during testing against 24.4