### PR TITLE
Failing test idents-class-func-declaration/2/1: indentation error in class/function body...

### DIFF
--- a/test/indentation-tests.el
+++ b/test/indentation-tests.el
@@ -698,6 +698,36 @@ class func Foo() {
 }
 ")
 
+(check-indentation indents-class-func-declaration/2/1
+  "
+class Foo: Bar {
+    func Foo() {
+|foo
+    }
+}
+" "
+class Foo: Bar {
+    func Foo() {
+        |foo
+    }
+}
+")
+
+(check-indentation indents-class-func-declaration/2/2
+  "
+class Foo: Bar {
+    override func Foo() {
+|foo
+    }
+}
+" "
+class Foo: Bar {
+    override func Foo() {
+        |foo
+    }
+}
+")
+
 (check-indentation indents-declaration/1
   "
 var foo = bar + baz


### PR DESCRIPTION
... when function has no modifiers
Issue #81 