### PR TITLE
Fix indent when after comment

### DIFF
--- a/swift-mode.el
+++ b/swift-mode.el
@@ -225,10 +225,10 @@
              (looking-at "[ \n\t]+[.?:]")
              ;; Operators placed on the second line in multi-line expression
              ;; Should respect here possible comments strict before the linebreak
-             (and (looking-at
-                   (concat "\\(\/\/.*\\)?\n[[:space:]]*" swift-smie--operators-regexp))
-                  (not (looking-at
-                        (concat "\\(\/\/.*\\)?\n[[:space:]]*" "//"))))
+             (save-excursion
+               (forward-comment (buffer-size))
+               (looking-at swift-smie--operators-regexp))
+
              (and (looking-back swift-smie--operators-regexp (- (point) 3) t)
                   ;; Not a generic type
                   (not (looking-back "[[:upper:]]>" (- (point) 2) t)))

--- a/swift-mode.el
+++ b/swift-mode.el
@@ -225,7 +225,10 @@
              (looking-at "[ \n\t]+[.?:]")
              ;; Operators placed on the second line in multi-line expression
              ;; Should respect here possible comments strict before the linebreak
-             (looking-at (concat "\\(\/\/.*\\)?\n[[:space:]]*" swift-smie--operators-regexp))
+             (and (looking-at
+                   (concat "\\(\/\/.*\\)?\n[[:space:]]*" swift-smie--operators-regexp))
+                  (not (looking-at
+                        (concat "\\(\/\/.*\\)?\n[[:space:]]*" "//"))))
              (and (looking-back swift-smie--operators-regexp (- (point) 3) t)
                   ;; Not a generic type
                   (not (looking-back "[[:upper:]]>" (- (point) 2) t)))

--- a/test/indentation-tests.el
+++ b/test/indentation-tests.el
@@ -2009,6 +2009,21 @@ func foo() {
 }
 ")
 
+(check-indentation indents-expression-with-comment/3
+                   "
+func foo() {
+    foo()
+    //
+        |foo()
+}
+" "
+func foo() {
+    foo()
+    //
+    |foo()
+}
+")
+
 (provide 'indentation-tests)
 
 ;;; indentation-tests.el ends here


### PR DESCRIPTION
I fixed indent after comment.
- expected result:
```swift
func foo() {
    foo()
    //
    |foo()
}
```
- actual:
```swift
func foo() {
    foo()
    //
        |foo()
}
```