### PR TITLE
Fix indent in trailing closure

### DIFF
--- a/swift-mode.el
+++ b/swift-mode.el
@@ -375,7 +375,8 @@
     ;; "in" token in closure
     (`(:after . "in")
      (if (smie-rule-parent-p "{")
-         (smie-rule-parent swift-indent-offset)))
+         (smie-rule-parent swift-indent-offset)
+       (smie-rule-parent 0)))
 
     (`(:after . "(")
      (if (smie-rule-parent-p "(") 0

--- a/test/indentation-tests.el
+++ b/test/indentation-tests.el
@@ -1947,6 +1947,32 @@ foo.bar(10,
 )
 ")
 
+(check-indentation trailing-closure/1
+                   "
+a(){
+    (b: String, c:String) -> String in
+        |println(c)
+}
+" "
+a(){
+    (b: String, c:String) -> String in
+    |println(c)
+}
+")
+
+(check-indentation trailing-closure/2
+                   "
+a(){
+    b,c in
+        |println(c)
+}
+" "
+a(){
+    b,c in
+    |println(c)
+}
+")
+
 (check-indentation indents-expression-with-optional-type/1
                    "
 var object: JsonObject?


### PR DESCRIPTION
I fixed indent in trailing closure(https://developer.apple.com/library/prerelease/ios/documentation/Swift/Conceptual/Swift_Programming_Language/Closures.html).
- expected result:
```swift
a(){
    b,c in
    |println(c)
}
```
- actual:
```swift
a(){
    b,c in
        |println(c)
}
```