### PR TITLE
Fix indent when operator hanging after comment

### DIFF
--- a/swift-mode.el
+++ b/swift-mode.el
@@ -222,7 +222,9 @@
              ;; "in" operator in closure
              (looking-back "in" (- (point) 2) t)
              ;; Characters placed on the second line in multi-line expression
-             (looking-at "[ \n\t]+[.?:]")
+             (save-excursion
+               (forward-comment (buffer-size))
+               (looking-at "[.?:]"))
              ;; Operators placed on the second line in multi-line expression
              ;; Should respect here possible comments strict before the linebreak
              (looking-at (concat "\\(\/\/.*\\)?\n[[:space:]]*" swift-smie--operators-regexp))

--- a/test/indentation-tests.el
+++ b/test/indentation-tests.el
@@ -1607,6 +1607,21 @@ let a = a ?
 
 (check-indentation conditional-operator/8
                    "
+let a = a //foo
+        |? a +
+          1
+        : a +
+          1
+" "
+let a = a //foo
+        |? a +
+          1
+        : a +
+          1
+")
+
+(check-indentation conditional-operator/9
+                   "
 func foo() {
     return order!.deliver ?
          |OrderViewTableDeliveryCells.lastCellIndex.rawValue :
@@ -1620,7 +1635,7 @@ func foo() {
 }
 ")
 
-(check-indentation conditional-operator/9
+(check-indentation conditional-operator/10
                    "
 func foo() {
     return order!.deliver ?


### PR DESCRIPTION
I fixed indent when operator hanging after comment.
- expected result:
```swift
let a = a //foo
        |? a +
          1
        : a +
          1
```
- actual:
```swift
let a = a //foo
|? a +
          1
        : a +
          1
```