### PR TITLE
Fix half-open range operator

### DIFF
--- a/swift-mode.el
+++ b/swift-mode.el
@@ -180,7 +180,7 @@
        (left "&&")                                             ;; Conjunctive (Left associative, precedence level 120)
        (nonassoc "<" "<=" ">" ">=" "==" "!=" "===" "!==" "~=") ;; Comparative (No associativity, precedence level 130)
        (nonassoc "is" "as" "as?")                              ;; Cast (No associativity, precedence level 132)
-       (nonassoc ".." "...")                                   ;; Range (No associativity, precedence level 135)
+       (nonassoc "..<" "...")                                  ;; Range (No associativity, precedence level 135)
        (left "+" "-" "&+" "&-" "|" "^")                        ;; Additive (Left associative, precedence level 140)
        (left "*" "/" "%" "&*" "&/" "&%" "&")                   ;; Multiplicative (Left associative, precedence level 150)
        (nonassoc "<<" ">>")                                    ;; Exponentiative (No associativity, precedence level 160)
@@ -199,7 +199,7 @@
 (defvar swift-smie--operators-regexp
   (regexp-opt '("*=" "/=" "%=" "+=" "-=" "<<=" ">>=" "&=" "^=" "|=" "&&=" "||="
                 "<" "<=" ">" ">=" "==" "!=" "===" "!==" "~=" "||" "&&"
-                "is" "as" "as?" ".." "..."
+                "is" "as" "as?" "..<" "..."
                 "+" "-" "&+" "&-" "|" "^"
                 "*" "/" "%" "&*" "&/" "&%" "&"
                 "<<" ">>" "??")))


### PR DESCRIPTION
It was changed in one of the first versions of Swift