### PR TITLE
Modify indents around comma to meet Xcode spec

### DIFF
--- a/swift-mode.el
+++ b/swift-mode.el
@@ -370,8 +370,8 @@
     ;; Indent second line of the multi-line class
     ;; definitions with swift-indent-offset
     (`(:before . ",")
-     (if (smie-rule-parent-p "class")
-       (smie-rule-parent swift-indent-offset)))
+     (if (smie-rule-parent-p "class" "case")
+       (smie-rule-parent)))
 
     ;; Disable unnecessary default indentation for
     ;; "func" and "class" keywords

--- a/test/indentation-tests.el
+++ b/test/indentation-tests.el
@@ -486,7 +486,7 @@ case foo where bar,
 " "
 switch true {
 case foo where bar,
-     |bar where baz:
+|bar where baz:
 }
 ")
 
@@ -685,7 +685,7 @@ class Foo: Foo, Bar,
 }
 " "
 class Foo: Foo, Bar,
-    |Baz {
+|Baz {
 }
 ")
 
@@ -725,7 +725,7 @@ public class Foo: Foo, Bar,
 }
 " "
 public class Foo: Foo, Bar,
-    |Baz {
+|Baz {
 }
 ")
 

--- a/test/indentation-tests.el
+++ b/test/indentation-tests.el
@@ -59,6 +59,8 @@ values of customisable variables."
               (swift-indent-offset 4)
               (swift-indent-switch-case-offset 0)
               (swift-indent-multiline-statement-offset 2)
+              ;; Change from default value to detect offset bug.
+              (swift-indent-hanging-comma-offset 3)
               ,@var-bindings)
          (with-temp-buffer
            (insert ,before)
@@ -486,7 +488,7 @@ case foo where bar,
 " "
 switch true {
 case foo where bar,
-|bar where baz:
+   |bar where baz:
 }
 ")
 
@@ -685,7 +687,7 @@ class Foo: Foo, Bar,
 }
 " "
 class Foo: Foo, Bar,
-|Baz {
+   |Baz {
 }
 ")
 
@@ -725,7 +727,7 @@ public class Foo: Foo, Bar,
 }
 " "
 public class Foo: Foo, Bar,
-|Baz {
+   |Baz {
 }
 ")
 


### PR DESCRIPTION
I fixed indents around comma to meet Xcode(6.4) spec.
# case statement
 - expected result from Xcode
```swift
switch true {
case foo where bar,
|bar where baz:
 }
```
 - actual:
```swift
switch true {
case foo where bar,
    |bar where baz:
 }
```

# class statement

- expected result from Xcode
```swift
class Foo: Foo, Bar,
|Baz {
 }
```
- actual
```swift
class Foo: Foo, Bar,
    |Baz {
 }
```