### PR TITLE
Fix lexer

### DIFF
--- a/swift-mode.el
+++ b/swift-mode.el
@@ -218,7 +218,7 @@
                 "<<" ">>" "??")))
 
 (defvar swift-smie--decl-specifier-regexp
-  "\\(?1:class\\|mutating\\|override\\|static\\|unowned\\|weak\\)\\(?:[[:space:]]*func\\)")
+  "\\(?1:class\\|mutating\\|override\\|static\\|unowned\\|weak\\)")
 
 (defvar swift-smie--access-modifier-regexp
   (regexp-opt '("private" "public" "internal")))

--- a/swift-mode.el
+++ b/swift-mode.el
@@ -288,7 +288,9 @@
 
    ((looking-at "<") (forward-char 1)
     (if (looking-at "[[:upper:]]") "<T" "OP"))
-   ((looking-at ">") (forward-char 1)
+
+   ((looking-at ">[?!]?")
+    (goto-char (match-end 0))
     (if (looking-back "[[:space:]]>" 2 t) "OP" "T>"))
 
    ((looking-at swift-smie--operators-regexp)

--- a/swift-mode.el
+++ b/swift-mode.el
@@ -218,7 +218,7 @@
                 "<<" ">>" "??")))
 
 (defvar swift-smie--decl-specifier-regexp
-  "\\(?1:class\\|mutating\\|override\\|static\\|unowned\\|weak\\)")
+  "\\(?1:mutating\\|override\\|static\\|unowned\\|weak\\)")
 
 (defvar swift-smie--access-modifier-regexp
   (regexp-opt '("private" "public" "internal")))
@@ -349,6 +349,10 @@
      ((looking-back ">[?!]?" (- (point) 2) t)
       (goto-char (match-beginning 0))
       (if (looking-back "[[:space:]]" 1 t) "OP" "T>"))
+
+     ((looking-back (regexp-opt swift-mode--type-decl-keywords) (- (point) 9) t)
+      (goto-char (match-beginning 0))
+      (match-string-no-properties 0))
 
      ((looking-back swift-smie--operators-regexp (- (point) 3) t)
       (goto-char (match-beginning 0)) "OP")
@@ -762,7 +766,7 @@ You can send text to the REPL process from other buffers containing source.
   (let ((table (make-syntax-table)))
 
     ;; Operators
-    (dolist (i '(?+ ?- ?* ?/ ?& ?| ?^ ?! ?< ?> ?~))
+    (dolist (i '(?+ ?- ?* ?/ ?& ?| ?^ ?< ?> ?~))
       (modify-syntax-entry i "." table))
 
     ;; Strings
@@ -771,6 +775,8 @@ You can send text to the REPL process from other buffers containing source.
 
     ;; Additional symbols
     (modify-syntax-entry ?_ "w" table)
+    (modify-syntax-entry ?? "_" table)
+    (modify-syntax-entry ?! "_" table)
     (modify-syntax-entry ?: "_" table)
 
     ;; Comments

--- a/swift-mode.el
+++ b/swift-mode.el
@@ -249,6 +249,22 @@
                   (not (looking-back "[[:upper:]]>" (- (point) 2) t)))
              ))))
 
+(defun swift-smie--forward-token-debug ()
+  (let ((token (swift-smie--forward-token)))
+    (unless (equal token "")
+      (assert (equal token
+                     (save-excursion (swift-smie--backward-token))) t))
+    token
+    ))
+
+(defun swift-smie--backward-token-debug ()
+  (let ((token (swift-smie--backward-token)))
+    (unless (equal token "")
+      (assert (equal token
+                     (save-excursion (swift-smie--forward-token))) t))
+      token
+    ))
+
 (defun swift-smie--forward-token ()
   (skip-chars-forward " \t")
   (cond

--- a/swift-mode.el
+++ b/swift-mode.el
@@ -32,6 +32,7 @@
 
 (require 'rx)
 (require 'comint)
+(require 'cl-lib)
 
 (eval-and-compile
   ;; Added in Emacs 24.3
@@ -252,7 +253,7 @@
 (defun swift-smie--forward-token-debug ()
   (let ((token (swift-smie--forward-token)))
     (unless (equal token "")
-      (assert (equal token
+      (cl-assert (equal token
                      (save-excursion (swift-smie--backward-token))) t))
     token
     ))
@@ -260,7 +261,7 @@
 (defun swift-smie--backward-token-debug ()
   (let ((token (swift-smie--backward-token)))
     (unless (equal token "")
-      (assert (equal token
+      (cl-assert (equal token
                      (save-excursion (swift-smie--forward-token))) t))
       token
     ))

--- a/swift-mode.el
+++ b/swift-mode.el
@@ -777,7 +777,7 @@ You can send text to the REPL process from other buffers containing source.
     (modify-syntax-entry ?_ "w" table)
     (modify-syntax-entry ?? "_" table)
     (modify-syntax-entry ?! "_" table)
-    (modify-syntax-entry ?: "_" table)
+    (modify-syntax-entry ?: "." table)
 
     ;; Comments
     (modify-syntax-entry ?/  ". 124b" table)

--- a/swift-mode.el
+++ b/swift-mode.el
@@ -443,8 +443,12 @@
        (smie-rule-parent 0)))
 
     (`(:after . "(")
-     (if (smie-rule-parent-p "(") 0
-       (smie-rule-parent swift-indent-offset)))
+     (cond
+      ((smie-rule-parent-p "(") 0)
+      ((and (smie-rule-parent-p "." "func")
+            (not (smie-rule-hanging-p))) 1)
+      (t (smie-rule-parent swift-indent-offset))))
+
     (`(:before . "(")
      (cond
       ((smie-rule-next-p "[") (smie-rule-parent))

--- a/test/indentation-tests.el
+++ b/test/indentation-tests.el
@@ -1215,7 +1215,7 @@ foo?[bar] +
      |a
 " "
 foo?[bar] +
-     |a
+  |a
 ")
 
 (check-indentation indents-multiline-expressions/10
@@ -1224,7 +1224,7 @@ foo?(bar) +
      |a
 " "
 foo?(bar) +
-     |a
+  |a
 ")
 
 (check-indentation indents-multiline-expressions/11

--- a/test/indentation-tests.el
+++ b/test/indentation-tests.el
@@ -68,6 +68,8 @@ values of customisable variables."
            (search-forward "|")
            (delete-char -1)
            (swift-mode)
+           (setq smie-forward-token-function 'swift-smie--forward-token-debug)
+           (setq smie-backward-token-function 'swift-smie--backward-token-debug)
            (indent-according-to-mode)
 
            (should (equal expected-state (buffer-string)))


### PR DESCRIPTION
Sometime lexer returns different tokens between ```swift-smie--backward-token``` and ```swift-smie--forward-token```. The examples is below.
- When "foo:", forward-token returns "foo:" but backward-token returns "foo" and ":".
- When "typealias", forward-token returns "typealias" but backward-token returns "typeali" and "as".

So I add test code to check ```swift-smie--backward-token``` and ```swift-smie--forward-token```. And fix those lexer.
How about this?