### PR TITLE
Fix move by sexp

### DIFF
--- a/swift-mode.el
+++ b/swift-mode.el
@@ -286,8 +286,8 @@ We try to constraint those lookups by reasonable number of lines.")
 
    ((looking-at ",") (forward-char 1) ",")
    ((looking-at ":") (forward-char 1)
-    ;; look-back until "case", ":", "{", ";"
-    (if (looking-back "case[\n\t ][^:{;]+:")
+    ;; look-back until "case", "default", ":", "{", ";"
+    (if (looking-back "\\(case[\n\t ][^:{;]+\\|default[\n\t ]*\\):")
         "case-:"
       ":"))
 
@@ -342,8 +342,8 @@ We try to constraint those lookups by reasonable number of lines.")
 
      ((eq (char-before) ?,) (backward-char 1) ",")
      ((eq (char-before) ?:) (backward-char 1)
-      ;; look-back until "case", ":", "{", ";"
-      (if (looking-back "case[\n\t ][^:{;]+")
+      ;; look-back until "case", "default", ":", "{", ";"
+      (if (looking-back "\\(case[\n\t ][^:{;]+\\|default[\n\t ]*\\)")
           "case-:"
         ":"))
 

--- a/swift-mode.el
+++ b/swift-mode.el
@@ -107,8 +107,8 @@
        (top-level-st
         ("import" type)
         (decl)
-        ("ACCESSMOD" "class" class-decl-exp "class-{" class-level-sts "}")
-        ("ACCESSMOD" "protocol" class-decl-exp "protocol-{" protocol-level-sts "}")
+        ("ACCESSMOD" "class" class-decl-exp "{" class-level-sts "}")
+        ("ACCESSMOD" "protocol" class-decl-exp "{" protocol-level-sts "}")
         )
 
        (class-level-sts (class-level-st) (class-level-st ";" class-level-st))
@@ -278,11 +278,10 @@ We try to constraint those lookups by reasonable number of lines.")
    ((and (looking-at "\n\\|\/\/") (swift-smie--implicit-semi-p))
     (if (eolp) (forward-char 1) (forward-comment 1))
     ";")
-
-   ((looking-at "{") (forward-char 1)
-    (if (looking-back "\\(class\\|protocol\\) [^{]+{" (line-beginning-position swift-smie--lookback-max-lines) t)
-        (concat (match-string 1) "-{")
-      "{"))
+   (t
+    (forward-comment (point))
+    (cond
+   ((looking-at "{") (forward-char 1) "{")
    ((looking-at "}") (forward-char 1) "}")
 
    ((looking-at ",") (forward-char 1) ",")
@@ -327,6 +326,7 @@ We try to constraint those lookups by reasonable number of lines.")
             "else"))
          (t tok))))
    ))
+   ))
 
 (defun swift-smie--backward-token ()
   (let ((pos (point)))
@@ -336,10 +336,7 @@ We try to constraint those lookups by reasonable number of lines.")
            (swift-smie--implicit-semi-p))
       ";")
 
-     ((eq (char-before) ?\{) (backward-char 1)
-      (if (looking-back "\\(class\\|protocol\\) [^{]+" (line-beginning-position swift-smie--lookback-max-lines) t)
-          (concat (match-string 1) "-{")
-        "{"))
+     ((eq (char-before) ?\{) (backward-char 1) "{")
      ((eq (char-before) ?\}) (backward-char 1) "}")
 
      ((eq (char-before) ?,) (backward-char 1) ",")

--- a/swift-mode.el
+++ b/swift-mode.el
@@ -286,7 +286,8 @@ We try to constraint those lookups by reasonable number of lines.")
 
    ((looking-at ",") (forward-char 1) ",")
    ((looking-at ":") (forward-char 1)
-    (if (looking-back "\\(case [^:]+\\|default\\):" (line-beginning-position 0) t)
+    ;; look-back until "case", ":", "{", ";"
+    (if (looking-back "case[\n\t ][^:{;]+:")
         "case-:"
       ":"))
 
@@ -341,7 +342,8 @@ We try to constraint those lookups by reasonable number of lines.")
 
      ((eq (char-before) ?,) (backward-char 1) ",")
      ((eq (char-before) ?:) (backward-char 1)
-      (if (looking-back "case [^:]+\\|default" (line-beginning-position 0))
+      ;; look-back until "case", ":", "{", ";"
+      (if (looking-back "case[\n\t ][^:{;]+")
           "case-:"
         ":"))
 

--- a/test/indentation-tests.el
+++ b/test/indentation-tests.el
@@ -72,7 +72,12 @@ values of customisable variables."
            (indent-according-to-mode)
 
            (should (equal expected-state (buffer-string)))
-           (should (equal expected-cursor-pos (point))))))))
+           (should (equal expected-cursor-pos (point)))
+
+           (goto-char (point-min))
+           (forward-sexp 10)
+           (should (equal (point-max) (point)))
+           )))))
 
 ;; Provide font locking for easier test editing.
 

--- a/test/indentation-tests.el
+++ b/test/indentation-tests.el
@@ -1186,10 +1186,10 @@ let foo = [
 (check-indentation indents-declaration/12
   "
 let foo = [
-|[
+|[]]
 " "
 let foo = [
-    |[
+    |[]]
 ")
 
 (check-indentation indents-declaration/13
@@ -2053,12 +2053,12 @@ foo.bar(10,
 foo.bar(10,
         completionHandler: { (bar, baz) -> Void in
         |foo
-        }
+        })
 " "
 foo.bar(10,
         completionHandler: { (bar, baz) -> Void in
             |foo
-        }
+        })
 ")
 
 (check-indentation anonymous-function-as-a-argument/9

--- a/test/indentation-tests.el
+++ b/test/indentation-tests.el
@@ -77,6 +77,8 @@ values of customisable variables."
            (goto-char (point-min))
            (forward-sexp 10)
            (should (equal (point-max) (point)))
+           (forward-sexp -10)
+           (should (equal (point-min) (point)))
            )))))
 
 ;; Provide font locking for easier test editing.

--- a/test/indentation-tests.el
+++ b/test/indentation-tests.el
@@ -1388,10 +1388,10 @@ func a () {
 (check-indentation indents-multiline-expressions/13
                    "
 if (a
-|.b)
+|.b){}
 " "
 if (a
-     |.b)
+     |.b){}
 ")
 
 (check-indentation indents-multiline-expressions/14


### PR DESCRIPTION
Both forward-sexp(M-C-f) and backward-sexp(M-C-b) are easy to be broken by changing grammar(eg. #97). So I add test code to check forward-sexp and backward-sexp. And I fixed failed test.
How about this?