### PR TITLE
Remove needless code

### DIFF
--- a/swift-mode.el
+++ b/swift-mode.el
@@ -34,13 +34,6 @@
 (require 'comint)
 (require 'cl-lib)
 
-(eval-and-compile
-  ;; Added in Emacs 24.3
-  (unless (fboundp 'setq-local)
-    (defmacro setq-local (var val)
-      "Set variable VAR to value VAL in current buffer."
-      (list 'set (list 'make-local-variable (list 'quote var)) val))))
-
 (defgroup swift nil
   "Configuration for swift-mode."
   :group 'languages


### PR DESCRIPTION
Because swift-mode requires Emacs 24.4 or higher.