### PR TITLE
Fix indent for ternary operator

### DIFF
--- a/swift-mode.el
+++ b/swift-mode.el
@@ -88,13 +88,11 @@
        (decl (decl ";" decl))
        (decl (let-decl) (var-decl))
        (let-decl
-        ("let" id ":" type)
-        ("let" id "=" exp)
-        ("let" id ":" type "=" exp))
+        ("let" decl-exp)
+        ("let" decl-exp "=" exp))
        (var-decl
-        ("var" id ":" type)
-        ("var" id "=" exp)
-        ("var" id ":" type "=" exp))
+        ("var" decl-exp)
+        ("var" decl-exp "=" exp))
 
        (top-level-sts (top-level-st) (top-level-st ";" top-level-st))
        (top-level-st
@@ -125,7 +123,6 @@
        (insts (inst) (insts ";" insts))
        (inst (decl)
              (exp "=" exp)
-             (tern-exp)
              (in-exp)
              (dot-exp)
              (dot-exp "{" closure "}")
@@ -147,7 +144,6 @@
        (exp ("[" decl-exps "]"))
        (in-exp (id "in" exp))
        (guard-exp (exp "where" exp))
-       (tern-exp (exp "?" exp ":" exp))
 
        (enum-case ("ecase" assign-exp)
                   ("ecase" "(" type ")"))
@@ -173,7 +169,7 @@
 
        (closure (insts) (exp "in" insts) (exp "->" id "in" insts)))
      ;; Conflicts
-     '((nonassoc "{") (assoc "in") (assoc ",") (assoc ";") (assoc ":") (right "="))
+     '((nonassoc "{") (assoc "in") (assoc ",") (assoc ";") (right "=") (right ":"))
      '((assoc "in") (assoc "where"))
      '((assoc ";") (assoc "ecase"))
      '((assoc "case")))
@@ -182,6 +178,7 @@
      '(
        (right "*=" "/=" "%=" "+=" "-=" "<<=" ">>=" "&="
               "^=" "|=" "&&=" "||=" "=")                       ;; Assignment (Right associative, precedence level 90)
+       (right "?" ":")                                         ;; Ternary Conditional (Right associative, precedence level 100)
        (left "||")                                             ;; Disjunctive (Left associative, precedence level 110)
        (left "&&")                                             ;; Conjunctive (Left associative, precedence level 120)
        (right "??")                                            ;; Nil Coalescing (Right associativity, precedence level 120)
@@ -386,8 +383,7 @@ We try to constraint those lookups by reasonable number of lines.")
      (cond
       ;; Rule for ternary operator in
       ;; assignment expression.
-      ;; Static indentation relatively to =
-      ((smie-rule-parent-p "=") 2)
+      ((and (smie-rule-parent-p "?") (smie-rule-bolp)) 0)
       ((smie-rule-parent-p ",") (smie-rule-parent swift-indent-offset))
       ;; Rule for the class definition.
       ((smie-rule-parent-p "class") (smie-rule-parent swift-indent-offset))))

--- a/test/indentation-tests.el
+++ b/test/indentation-tests.el
@@ -1836,6 +1836,19 @@ func foo() {
 }
 ")
 
+(check-indentation conditional-operator/11
+                   "
+let a = a ? a +
+              1
+        |: a +
+              1
+" "
+let a = a ? a +
+              1
+          |: a +
+              1
+")
+
 (check-indentation blank-line/1
                    "
 func foo() {


### PR DESCRIPTION
I fixed indent for ternary operator.
- expected result:
```swift
let a = a ? a +
              1
          : a +
              1
```
- actual:
```swift
let a = a ? a +
              1
        : a +
            1
```
PS: @ap4y, Thanks for adding my name to [contributors](064d4ee30d13d0b2)!