### PR TITLE
Swift 2 support

### DIFF
--- a/swift-mode.el
+++ b/swift-mode.el
@@ -247,7 +247,7 @@ class Foo:
         ;; supresses implicit semicolon before operator
         (progn
           (forward-comment (point-max))
-          (looking-at "[-.,!#$%&=^~\\|+:*<>?]"))
+          (looking-at "[-.,!$%&=^~\\|+:*<>?]"))
         ;; supresses implicit semicolon before keyword
         (save-excursion
           ;; note that comments are already skipped by previous condition

--- a/swift-mode.el
+++ b/swift-mode.el
@@ -1094,6 +1094,7 @@ and returns nil"
    (list "Enums"     (swift-mode--mk-regex-for-def "enum") 1)
    (list "Protocols" (swift-mode--mk-regex-for-def "protocol") 1)
    (list "Structs"   (swift-mode--mk-regex-for-def "struct") 1)
+   (list "Extensions"   (swift-mode--mk-regex-for-def "extension") 1)
    (list "Constants" (swift-mode--mk-regex-for-def "let") 1)
    (list "Variables" (swift-mode--mk-regex-for-def "var") 1))
   "Value for `imenu-generic-expression' in swift-mode.")

--- a/swift-mode.el
+++ b/swift-mode.el
@@ -100,6 +100,7 @@ class Foo:
       (for)
       (if)
       (guard)
+      (while)
       (do)
       (where)
       (insts ";" insts)
@@ -137,6 +138,8 @@ class Foo:
      (if (id "if" let "else" id) (id "if" expr "else" id))
      ;; guard statement.
      (guard (id "guard" let "else" id) (id "guard" expr "else" id))
+     ;; while statement.
+     (while (id "while" expr))
      ;; do statement.
      (do (id "do" block "catch" expr))
      ;; where clause
@@ -605,7 +608,7 @@ OFFSET is a offset from parent tokens, or 0 if omitted."
        (swift-smie--forward-token)
        (swift-smie--backward-token)
        (cons 'column (current-column))))
-    (`(:after . ,(or "class" "func" "enum" "switch" "case" "for" "if" "let" "var" "catch" "where" "indirect" "guard"))
+    (`(:after . ,(or "class" "func" "enum" "switch" "case" "for" "if" "while" "let" "var" "catch" "where" "indirect" "guard"))
      ;; i.e.
      ;;
      ;; switch
@@ -658,6 +661,11 @@ OFFSET is a offset from parent tokens, or 0 if omitted."
            (cons
             'column
             (+ swift-indent-multiline-statement-offset (current-column)))))))
+    (`(:before . "while")
+     (when (and (not (smie-indent--bolp-1))
+                (equal (save-excursion (swift-smie--backward-token)) "}"))
+       ;; repeat { ... } while
+       (cons 'column (current-column))))
     ))
 
 (defun swift-smie--rule-before-semicolon (implicit)
@@ -868,7 +876,7 @@ and returns nil"
 (defvar swift-mode--statement-keywords
   '("break" "case" "continue" "default" "do" "else" "fallthrough"
     "if" "in" "for" "return" "throw" "switch" "catch" "where" "while" "guard"
-    "defer"))
+    "defer" "repeat"))
 
 (defvar swift-mode--contextual-keywords
   '("associativity" "didSet" "get" "infix" "inout" "left" "mutating" "none"

--- a/swift-mode.el
+++ b/swift-mode.el
@@ -253,7 +253,7 @@
   "Return t if a colon at the cursor is the colon for supertype declaration or type declaration of let or var."
   (save-excursion
     (or (equal (smie-default-backward-token) ">")
-        (member (smie-default-backward-token) '("class" "let" "var")))))
+        (member (smie-default-backward-token) '("class" "extension" "let" "var")))))
 
 (defun swift-smie--forward-token-debug ()
   (let ((token (swift-smie--forward-token)))

--- a/swift-mode.el
+++ b/swift-mode.el
@@ -282,11 +282,29 @@ let x = someFunction(
 (defun swift-smie--is-type-colon ()
   "Return t if a colon at the cursor is the colon for supertype declaration or type declaration of let or var."
   (save-excursion
-    (or (looking-back "[[:alnum:]_][])>]*> *" (- (point) 32) nil) ;; Foo<[(a, b)]>:
-
+    ;; class Foo<T>: Bar ← type colon
+    ;; class Foo<T> : Bar ← type colon
+    ;; class Foo<T where T: Bar<[(Int, String)]>> : Bar ← type colon
+    ;; case Foo: ← not a type colon
+    ;; case Foo where foo: ← not a type colon
+    ;; default: ← not a type colon
+    ;; foo ? bar : baz ← not a type colon
+    ;; [
+    ;;   foo: ← not a type colon
+    ;;     bar
+    ;; ]
+    ;; foo(bar, baz: baz) ← not a type colon
+    (or (looking-back "[[:alnum:]_][])>]*> *" (- (point) 32) nil)
+        ;; class Foo: ← type colon
+        ;; extension Foo: ← type colon
+        ;; let foo: ← type colon
+        ;; var foo: ← type colon
+        ;; protocol Foo {
+        ;;   typealias Bar: Baz ← type colon
+        ;; }
         (progn
           (smie-default-backward-token)
-          (member (smie-default-backward-token) '("class" "extension" "let" "var"))))))
+          (member (smie-default-backward-token) '("class" "extension" "enum" "struct" "protocol" "typealias" "let" "var"))))))
 
 (defun swift-smie--forward-token-debug ()
   (let ((token (swift-smie--forward-token)))

--- a/swift-mode.el
+++ b/swift-mode.el
@@ -1226,7 +1226,10 @@ You can send text to the REPL process from other buffers containing source.
 
   (setq-local comment-start "// ")
   (setq-local comment-end "")
-  (setq-local comment-start-skip "\\(//+\\|/\\*+\\)\\s *")
+  ;; ":" is for Playground Rich Comments Markup Syntax:
+  ;; https://developer.apple.com/library/prerelease/ios/documentation/Xcode/Reference/xcode_markup_formatting_ref/PlaygroundRichComments.html
+  (setq-local comment-start-skip "\\(//+:?\\|/\\*+:?\\)\\s *")
+  (setq-local adaptive-fill-regexp comment-start-skip)
   (setq-local indent-tabs-mode nil)
   (setq-local electric-indent-chars
               (append '(?. ?, ?: ?\) ?\] ?\}) electric-indent-chars))

--- a/swift-mode.el
+++ b/swift-mode.el
@@ -99,6 +99,7 @@ class Foo:
       (var)
       (for)
       (if)
+      (guard)
       (do)
       (where)
       (insts ";" insts)
@@ -134,6 +135,8 @@ class Foo:
      (for (id "for" expr ";" expr ";" expr) (id "for" expr "in" expr))
      ;; if statement.
      (if (id "if" let "else" id) (id "if" expr "else" id))
+     ;; guard statement.
+     (guard (id "guard" let "else" id) (id "guard" expr "else" id))
      ;; do statement.
      (do (id "do" block "catch" expr))
      ;; where clause
@@ -243,7 +246,7 @@ class Foo:
         ;; supresses implicit semicolon after keyword
         ;; Note that "as?" is already handled by preceeding conditions.
         (save-excursion
-          (member (smie-default-backward-token) '("as" "is" "try" "class" "deinit" "enum" "extension" "func" "import" "init" "internal" "let" "operator" "private" "protocol" "public" "static" "struct" "subscript" "typealias" "var" "case" "for" "if" "return" "throw" "switch" "where" "while" "associativity" "convenience" "dynamic" "didSet" "final" "get" "infix" "inout" "lazy" "mutating" "nonmutating" "optional" "override" "postfix" "precedence" "prefix" "required" "set" "unowned" "weak" "willSet" "throws" "rethrows" "catch" "indirect")))
+          (member (smie-default-backward-token) '("as" "is" "try" "class" "deinit" "enum" "extension" "func" "import" "init" "internal" "let" "operator" "private" "protocol" "public" "static" "struct" "subscript" "typealias" "var" "case" "for" "if" "return" "throw" "switch" "where" "while" "associativity" "convenience" "dynamic" "didSet" "final" "get" "infix" "inout" "lazy" "mutating" "nonmutating" "optional" "override" "postfix" "precedence" "prefix" "required" "set" "unowned" "weak" "willSet" "throws" "rethrows" "catch" "indirect" "guard")))
         ;; supresses implicit semicolon before operator
         (progn
           (forward-comment (point-max))
@@ -602,7 +605,7 @@ OFFSET is a offset from parent tokens, or 0 if omitted."
        (swift-smie--forward-token)
        (swift-smie--backward-token)
        (cons 'column (current-column))))
-    (`(:after . ,(or "class" "func" "enum" "switch" "case" "for" "if" "let" "var" "catch" "where" "indirect"))
+    (`(:after . ,(or "class" "func" "enum" "switch" "case" "for" "if" "let" "var" "catch" "where" "indirect" "guard"))
      ;; i.e.
      ;;
      ;; switch

--- a/swift-mode.el
+++ b/swift-mode.el
@@ -214,10 +214,10 @@ class Foo:
       ;; return foo +*! ← not inserts ";" here
       ;; return foo ? ← not inserts ";" here
       (and (looking-back "[][:alnum:]_)>][?!]" (- (point) 2) t)
-           (not (member (save-excursion
-                          (smie-default-backward-token)
-                          (smie-default-backward-token))
-                        '("as" "is"))))
+           (not (equal (save-excursion
+                         (smie-default-backward-token)
+                         (smie-default-backward-token))
+                       "as")))
 
       ;; otherwise, insert a implicit semicolon unless some conditions met.
       (not
@@ -311,7 +311,7 @@ class Foo:
               ))
            ((equal tok "=") "=")
            ((equal tok "as")
-            (when (eq (char-after) ??) ; "as?"
+            (when (member (char-after) '(?? ?!)) ; "as?" or "as!"
               (forward-char))
             "OP")
            ((equal tok "is") "OP")
@@ -362,6 +362,12 @@ class Foo:
             "TYPE:")
            ((equal tok ":")
             (if (swift-smie--is-type-colon) "TYPE:" ":"))
+           ((equal tok "!")
+            (let ((pos (point)))
+              (if (equal (smie-default-backward-token) "as") ; "as!"
+                  "OP"
+                (goto-char pos)
+                "OP")))
            ((equal tok "?")
             (let ((pos (point)))
               (if (equal (smie-default-backward-token) "as") ; "as?"

--- a/swift-mode.el
+++ b/swift-mode.el
@@ -44,16 +44,6 @@
   :group 'swift
   :type 'integer)
 
-(defcustom swift-indent-supertype-offset 4
-  "Defines the indentation offset for supertypes.
-
-example:
-class Foo:
-    Bar ← offset for this line"
-  :group 'swift
-  :type 'integer
-  :package-version '(swift-mode "0.4.0"))
-
 (defcustom swift-indent-switch-case-offset 0
   "Defines the indentation offset for cases in a switch statement."
   :group 'swift
@@ -500,9 +490,9 @@ OFFSET is a offset from parent tokens, or 0 if omitted."
     (`(:before . ,(or "OP" "?" "=" "throws" "rethrows"))
      (swift-smie--rule-before-op))
     (`(:after . "TYPE:")
-     (swift-smie--rule-after-op nil swift-indent-supertype-offset))
+     (swift-smie--rule-after-op nil swift-indent-multiline-statement-offset))
     (`(:before . "TYPE:")
-     (swift-smie--rule-before-op nil swift-indent-supertype-offset))
+     (swift-smie--rule-before-op nil swift-indent-multiline-statement-offset))
 
     (`(:after . ":")
      ;; If this is a ":" token of case or default clause, indent with standard
@@ -565,7 +555,7 @@ OFFSET is a offset from parent tokens, or 0 if omitted."
                    '(","))))
        (cons
         'column
-        (if (equal (nth 2 parent) "TYPE:")
+        (if (and swift-indent-hanging-comma-offset (member (nth 2 parent) '("TYPE:" "case")))
             ;; class Foo: Bar,
             ;;     Buz
             ;;
@@ -573,12 +563,9 @@ OFFSET is a offset from parent tokens, or 0 if omitted."
             ;;
             ;; class Foo: Bar,
             ;;            Buz
-            ;;
-            ;; If you prefer latter indentation, replace this if-expression
-            ;; with a (current-column).
             (progn
               (goto-char (nth 1 parent))
-              (+ (smie-indent-virtual) swift-indent-supertype-offset))
+              (+ (smie-indent-virtual) swift-indent-hanging-comma-offset))
           (current-column)))))
 
     (`(:before . "IMP;")

--- a/swift-mode.el
+++ b/swift-mode.el
@@ -887,6 +887,9 @@ and returns nil"
     "UIApplicationMain" "warn_unused_result" "convention" "IBAction"
     "IBDesignable" "IBInspectable" "IBOutlet"))
 
+(defvar swift-mode--compiler-control-statement-keywords
+  '("available" "if" "else" "elseif" "endif" "line"))
+
 (defvar swift-mode--keywords
   (append swift-mode--type-decl-keywords
           swift-mode--val-decl-keywords
@@ -923,6 +926,14 @@ and returns nil"
        `(and "@" bow (or ,@swift-mode--attribute-keywords) eow)
        t)
      0 font-lock-keyword-face)
+
+    ;; Compiler Control Statements
+    ;;
+    ;; Highlight compiler control statements with keyword face
+    (,(rx-to-string
+       `(and "#" bow (or ,@swift-mode--compiler-control-statement-keywords) eow)
+       t)
+     0 font-lock-keyword-face t)
 
     ;; Types
     ;;

--- a/swift-mode.el
+++ b/swift-mode.el
@@ -95,7 +95,10 @@ class Foo:
       (switch)
       (case)
       (default)
+      (let)
+      (var)
       (for)
+      (if)
       (insts ";" insts)
       (insts "IMP;" insts))
      ;; expressions.
@@ -121,8 +124,14 @@ class Foo:
      ;; case label.
      (case (id "case" id ":" id))
      (default (id "default" id ":" id))
+     ;; let
+     (let (id "let" expr))
+     ;; var
+     (var (id "var" expr))
      ;; for statement.
      (for (id "for" expr ";" expr ";" expr) (id "for" expr "in" expr))
+     ;; if statement.
+     (if (id "if" let) (id "if" expr))
      ;; block.
      (block ("{" insts "}"))
      ;; types.
@@ -155,8 +164,6 @@ class Foo:
 (defconst swift-smie-grammar (smie-prec2->grammar swift-smie-prec2))
 
 ;; (insert (prin1-to-string swift-smie-grammar))
-
-
 
 (defun verbose-swift-smie-rules (kind token)
   (let ((value (swift-smie-rules kind token)))
@@ -539,7 +546,7 @@ OFFSET is a offset from parent tokens, or 0 if omitted."
                    ;; case bar,
                    ;; buz:
                    (append (remove "," swift-smie--expression-parent-tokens)
-                           '("TYPE:" "case"))
+                           '("TYPE:" "case" "let" "var"))
                    '(","))))
        (cons
         'column
@@ -586,7 +593,7 @@ OFFSET is a offset from parent tokens, or 0 if omitted."
        (swift-smie--forward-token)
        (swift-smie--backward-token)
        (cons 'column (current-column))))
-    (`(:after . ,(or "class" "func" "enum" "switch" "case" "for"))
+    (`(:after . ,(or "class" "func" "enum" "switch" "case" "for" "if" "let" "var"))
      ;; i.e.
      ;;
      ;; switch

--- a/test/indentation-tests.el
+++ b/test/indentation-tests.el
@@ -993,7 +993,7 @@ class Foo: Foo, Bar,
 }
 " "
 class Foo: Foo, Bar,
-      |Baz {
+           |Baz {
 }
 ")
 
@@ -1016,7 +1016,7 @@ class Foo:
 }
 " "
 class Foo:
-    |Foo, Bar, Baz {
+  |Foo, Bar, Baz {
 }
 ")
 
@@ -1035,7 +1035,7 @@ class Foo<A: B<C>>:
                    |Bar
 " "
 class Foo<A: B<C>>:
-    |Bar
+  |Bar
 ")
 
 (check-indentation indents-class-declaration/9
@@ -1075,7 +1075,7 @@ public class Foo: Foo, Bar,
 }
 " "
 public class Foo: Foo, Bar,
-             |Baz {
+                  |Baz {
 }
 ")
 
@@ -1192,7 +1192,7 @@ func Foo(aaaaaaaaa:
 }
 " "
 func Foo(aaaaaaaaa:
-         |AAAAAAAAA) {
+           |AAAAAAAAA) {
 }
 ")
 
@@ -1202,7 +1202,7 @@ func foo() ->
 |Foo
 " "
 func foo() ->
-    |Foo
+  |Foo
 ")
 
 (check-indentation indents-func-declaration/8
@@ -1211,7 +1211,7 @@ func foo() ->
 |(A, B) {}
 " "
 func foo() ->
-    |(A, B) {}
+  |(A, B) {}
 ")
 
 (check-indentation indents-func-declaration/9
@@ -1220,7 +1220,7 @@ func foo() ->
 |[A] {}
 " "
 func foo() ->
-    |[A] {}
+  |[A] {}
 ")
 
 (check-indentation indents-func-declaration/10
@@ -1413,7 +1413,7 @@ let foo =
 |bar
 " "
 let foo =
-    |bar
+  |bar
 ")
 
 (check-indentation indents-declaration/9
@@ -1422,7 +1422,7 @@ let foo: Foo? =
 |bar
 " "
 let foo: Foo? =
-    |bar
+  |bar
 ")
 
 (check-indentation indents-declaration/10
@@ -1431,7 +1431,7 @@ let foo: Foo<A> =
 |bar
 " "
 let foo: Foo<A> =
-    |bar
+  |bar
 ")
 
 (check-indentation indents-declaration/11
@@ -1443,7 +1443,7 @@ let foo = [
 " "
 let foo = [
     foo:
-    |bar
+      |bar
 ]
 ")
 
@@ -1666,7 +1666,7 @@ if (a
 |.b){}
 " "
 if (a
-     |.b){}
+      |.b){}
 ")
 
 (check-indentation indents-multiline-expressions/14
@@ -1897,7 +1897,7 @@ let options = NSRegularExpressionOptions.CaseInsensitive &
 |NSRegularExpressionOptions.DotMatchesLineSeparators
 " "
 let options = NSRegularExpressionOptions.CaseInsensitive &
-              |NSRegularExpressionOptions.DotMatchesLineSeparators
+                |NSRegularExpressionOptions.DotMatchesLineSeparators
 "
 ((swift-indent-multiline-statement-offset 4)))
 
@@ -1949,7 +1949,7 @@ let foo = bar >
 " "
 1 +
   2 + 5 *
-      |3
+  |3
 "
 )
 
@@ -2076,13 +2076,13 @@ let a = a //foo
 func foo() {
     return order!.deliver ?
          |OrderViewTableDeliveryCells.lastCellIndex.rawValue :
-           OrderViewTableTakeAwayCells.lastCellIndex.rawValue
+      OrderViewTableTakeAwayCells.lastCellIndex.rawValue
 }
 " "
 func foo() {
     return order!.deliver ?
-           |OrderViewTableDeliveryCells.lastCellIndex.rawValue :
-           OrderViewTableTakeAwayCells.lastCellIndex.rawValue
+      |OrderViewTableDeliveryCells.lastCellIndex.rawValue :
+      OrderViewTableTakeAwayCells.lastCellIndex.rawValue
 }
 ")
 
@@ -2090,14 +2090,14 @@ func foo() {
                    "
 func foo() {
     return order!.deliver ?
-           OrderViewTableDeliveryCells.lastCellIndex.rawValue :
+      OrderViewTableDeliveryCells.lastCellIndex.rawValue :
          |OrderViewTableTakeAwayCells.lastCellIndex.rawValue
 }
 " "
 func foo() {
     return order!.deliver ?
-           OrderViewTableDeliveryCells.lastCellIndex.rawValue :
-           |OrderViewTableTakeAwayCells.lastCellIndex.rawValue
+      OrderViewTableDeliveryCells.lastCellIndex.rawValue :
+      |OrderViewTableTakeAwayCells.lastCellIndex.rawValue
 }
 ")
 
@@ -2357,7 +2357,7 @@ foo.bar(10,
 " "
 foo.bar(10,
         completionHandler: { (
-            |bar, baz) in
+                                 |bar, baz) in
             foo
         }
 )

--- a/test/indentation-tests.el
+++ b/test/indentation-tests.el
@@ -2740,6 +2740,29 @@ try!
 }
 ")
 
+(check-indentation indents-repeat-while/1
+                   "
+repeat {
+|a
+} while a
+" "
+repeat {
+    |a
+} while a
+")
+
+(check-indentation indents-repeat-while/2
+                   "
+repeat {
+    a
+} while
+|a
+" "
+repeat {
+    a
+} while
+    |a
+")
 
 
 (provide 'indentation-tests)

--- a/test/indentation-tests.el
+++ b/test/indentation-tests.el
@@ -228,6 +228,33 @@ if foo {
 }
 ")
 
+(check-indentation indent-if-with-where/1
+  "
+if case foo = bar
+|where baz {
+    foo
+}
+" "
+if case foo = bar
+  |where baz {
+    foo
+}
+")
+
+(check-indentation indent-if-with-where/1
+  "
+if case foo = bar
+  where baz {
+|foo
+}
+" "
+if case foo = bar
+  where baz {
+    |foo
+}
+")
+
+
 (check-indentation indent-multiple-bindings-in-if-let
   "
 if let a = b,
@@ -529,7 +556,7 @@ case let .Foo(x) where x > 0:
 }
 ")
 
-(check-indentation indents-case-statements-with-guard
+(check-indentation indents-case-statements-with-guard/1
   "
 switch true {
 case foo where bar:
@@ -541,6 +568,76 @@ case foo where bar:
     |foo
 }
 ")
+
+(check-indentation indents-case-statements-with-guard/2
+  "
+switch true {
+case foo
+|where bar:
+    foo
+}
+" "
+switch true {
+case foo
+  |where bar:
+    foo
+}
+")
+
+(check-indentation indents-case-statements-with-guard/3
+  "
+switch true {
+case foo
+  where bar:
+|foo
+}
+" "
+switch true {
+case foo
+  where bar:
+    |foo
+}
+")
+
+(check-indentation indents-case-statements-with-guard/4
+  ;; should be like following?
+  ;; case foo
+  ;;   where
+  ;;   bar:
+  ;;     foo
+  "
+switch true {
+case foo
+  where
+|bar:
+    foo
+}
+" "
+switch true {
+case foo
+  where
+    |bar:
+    foo
+}
+")
+
+(check-indentation indents-case-statements-with-guard/5
+  "
+switch true {
+case foo
+  where
+    bar:
+|foo
+}
+" "
+switch true {
+case foo
+  where
+    bar:
+    |foo
+}
+")
+
 
 (check-indentation indents-case-statements-with-multiline-guard/1
   "
@@ -584,6 +681,26 @@ case foo where bar,
 }
 ")
 
+(check-indentation indents-case-statements-with-multiline-guard/3
+  "
+switch true {
+case foo
+  where
+    bar,
+     bar
+|where baz:
+    foo
+}
+" "
+switch true {
+case foo
+  where
+    bar,
+     bar
+  |where baz:
+    foo
+}
+")
 
 (check-indentation indents-case-statements-to-user-defined-offset/1
   "
@@ -643,6 +760,38 @@ enum Foo: Bar {
 }
 ")
 
+(check-indentation indents-case-statements-in-enum/4
+  "
+enum Foo: Bar {
+         |indirect case
+}
+" "
+enum Foo: Bar {
+    |indirect case
+}
+")
+
+(check-indentation indents-case-statements-in-enum/5
+  "
+indirect enum Foo: Bar {
+         |case
+}
+" "
+indirect enum Foo: Bar {
+    |case
+}
+")
+
+(check-indentation indents-indirect-enum/1
+  "
+indirect enum Foo: Bar {
+  |}
+" "
+indirect enum Foo: Bar {
+|}
+")
+
+
 (check-indentation indents-declaration-statements-in-enum/1
                    "
 enum Foo: Bar {
@@ -654,6 +803,21 @@ enum Foo: Bar {
 enum Foo: Bar {
     case foo
     case bar
+    |var foo
+}
+")
+
+(check-indentation indents-declaration-statements-in-enum/2
+                   "
+enum Foo: Bar {
+    case foo
+    indirect case bar
+         |var foo
+}
+" "
+enum Foo: Bar {
+    case foo
+    indirect case bar
     |var foo
 }
 ")
@@ -691,6 +855,33 @@ for var index = 0; index < 3; ++index  {
 }
 ")
 
+(check-indentation indents-for-statements-with-where/1
+  "
+for case foo in bar
+|where baz {
+    foo
+}
+" "
+for case foo in bar
+  |where baz {
+    foo
+}
+")
+
+(check-indentation indents-for-statements-with-where/2
+  "
+for case foo in bar
+  where baz {
+|foo
+}
+" "
+for case foo in bar
+  where baz {
+    |foo
+}
+")
+
+
 (check-indentation indents-while-statements
   "
 while foo < bar{
@@ -701,6 +892,33 @@ while foo < bar{
     |foo
 }
 ")
+
+(check-indentation indents-while-statements-with-where/1
+  "
+while case foo = bar
+|where baz {
+    foo
+}
+" "
+while case foo = bar
+  |where baz {
+    foo
+}
+")
+
+(check-indentation indents-while-statements-with-where/2
+  "
+while case foo = bar
+  where baz {
+|foo
+}
+" "
+while case foo = bar
+  where baz {
+    |foo
+}
+")
+
 
 (check-indentation indents-import-statements/1
   "
@@ -1042,6 +1260,33 @@ class Foo: Bar {
         |foo
     }
 }
+")
+
+(check-indentation indents-func-declaration-with-throws/1
+                   "
+func foo() throws ->
+|String
+" "
+func foo() throws ->
+  |String
+")
+
+(check-indentation indents-func-declaration-with-throws/2
+                   "
+func foo() throws
+|-> String
+" "
+func foo() throws
+  |-> String
+")
+
+(check-indentation indents-func-declaration-with-throws/3
+                   "
+func foo()
+|throws -> String
+" "
+func foo()
+  |throws -> String
 ")
 
 (check-indentation indents-protocol-declaration/1
@@ -2294,6 +2539,127 @@ guard let x = y else {
     |return
 }
 ")
+
+(check-indentation indents-do-statement/1
+                   "
+do {
+|foo
+} catch Foo {
+} catch Bar
+    where
+      b {
+}
+" "
+do {
+    |foo
+} catch Foo {
+} catch Bar
+    where
+      b {
+}
+")
+
+(check-indentation indents-do-statement/2
+                   "
+do {
+} catch Foo {
+|foo
+} catch Bar
+    where
+      b {
+}
+" "
+do {
+} catch Foo {
+    |foo
+} catch Bar
+    where
+      b {
+}
+")
+
+(check-indentation indents-do-statement/3
+                   "
+do {
+} catch Foo {
+} catch Bar
+|where
+      b {
+}
+" "
+do {
+} catch Foo {
+} catch Bar
+    |where
+      b {
+}
+")
+
+(check-indentation indents-do-statement/4
+                   "
+do {
+} catch Foo {
+} catch Bar
+    where
+|b {
+}
+" "
+do {
+} catch Foo {
+} catch Bar
+    where
+      |b {
+}
+")
+
+(check-indentation indents-do-statement/5
+                   "
+do {
+} catch Foo {
+} catch Bar
+    where
+      b {
+|foo
+}
+" "
+do {
+} catch Foo {
+} catch Bar
+    where
+      b {
+    |foo
+}
+")
+
+(check-indentation indents-try-expression/1
+                   "
+try
+|foo
+" "
+try
+  |foo
+")
+
+(check-indentation indents-try-expression/2
+                   "
+try?
+|foo
+" "
+try?
+  |foo
+")
+
+
+(check-indentation indents-try-expression/3
+                   "
+try!
+|foo
+" "
+try!
+  |foo
+")
+
+
 
 (provide 'indentation-tests)
 

--- a/test/indentation-tests.el
+++ b/test/indentation-tests.el
@@ -2540,6 +2540,18 @@ guard let x = y else {
 }
 ")
 
+(check-indentation indent-multiple-bindings-in-guard-let
+  "
+guard let a = b,
+|b = b {
+}
+" "
+guard let a = b,
+          |b = b {
+}
+")
+
+
 (check-indentation indents-do-statement/1
                    "
 do {

--- a/test/indentation-tests.el
+++ b/test/indentation-tests.el
@@ -228,6 +228,17 @@ if foo {
 }
 ")
 
+(check-indentation indent-multiple-bindings-in-if-let
+  "
+if let a = b,
+|b = b {
+}
+" "
+if let a = b,
+       |b = b {
+}
+")
+
 (check-indentation indents-case-statements-to-same-level-as-enclosing-switch/1
   "
 switch true {
@@ -1243,6 +1254,15 @@ let foo = [
         bar: baz
     |]
 ]
+")
+
+(check-indentation indents-declaration/16
+                   "
+let foo = 1,
+|bar = 2
+" "
+let foo = 1,
+    |bar = 2
 ")
 
 (check-indentation indents-expressions/1

--- a/test/indentation-tests.el
+++ b/test/indentation-tests.el
@@ -855,6 +855,33 @@ for var index = 0; index < 3; ++index  {
 }
 ")
 
+(check-indentation indents-for-statements/4
+  "
+for x in
+|xs {
+}
+" "
+for x in
+    |xs {
+}
+")
+
+(check-indentation indents-for-statements/5
+  "
+for
+|a;
+  b;
+  c {
+}
+" "
+for
+  |a;
+  b;
+  c {
+}
+")
+
+
 (check-indentation indents-for-statements-with-where/1
   "
 for case foo in bar
@@ -1262,6 +1289,68 @@ class Foo: Bar {
 }
 ")
 
+(check-indentation indents-func-declaration/13
+                   "
+protocol Foo {
+    func foo() ->
+|String
+}
+" "
+protocol Foo {
+    func foo() ->
+      |String
+}
+")
+
+(check-indentation indents-func-declaration/14
+                   "
+func foo() -> Foo<(A, B),
+|[C]>
+" "
+func foo() -> Foo<(A, B),
+                  |[C]>
+")
+
+(check-indentation indents-func-declaration/15
+                   "
+func a(a: a,
+       a: a
+       |= 1) {
+}
+" "
+func a(a: a,
+       a: a
+          |= 1) {
+}
+")
+
+(check-indentation indents-func-declaration/16
+                   "
+func foo(x:
+|Int,
+         y:
+           Int)
+" "
+func foo(x:
+           |Int,
+         y:
+           Int)
+")
+
+(check-indentation indents-func-declaration/17
+                   "
+func foo(x:
+           Int,
+         y:
+           |Int)
+" "
+func foo(x:
+           Int,
+         y:
+           |Int)
+")
+
+
 (check-indentation indents-func-declaration-with-throws/1
                    "
 func foo() throws ->
@@ -1508,6 +1597,41 @@ let foo = 1,
 " "
 let foo = 1,
     |bar = 2
+")
+
+(check-indentation indents-declaration/17
+                   "
+let f: Int
+|throws -> Int
+" "
+let f: Int
+  |throws -> Int
+")
+
+(check-indentation indents-declaration/18
+                   "
+let foo = [
+    foo:
+      bar,
+    foo:
+|bar
+]
+" "
+let foo = [
+    foo:
+      bar,
+    foo:
+      |bar
+]
+")
+
+(check-indentation indents-declaration/19
+                   "
+let foo
+|= 1
+" "
+let foo
+  |= 1
 ")
 
 (check-indentation indents-expressions/1
@@ -2762,6 +2886,46 @@ repeat {
     a
 } while
     |a
+")
+
+(check-indentation indents-continued-expression-after-keyword/1
+                   "
+func foo() {
+    return
+|1
+}
+" "
+func foo() {
+    return
+      |1
+}
+")
+
+(check-indentation indents-continued-expression-after-keyword/2
+                   "
+while
+|1
+" "
+while
+  |1
+")
+
+(check-indentation indents-continued-expression-after-keyword/3
+                   "
+switch
+|1
+" "
+switch
+  |1
+")
+
+(check-indentation indents-continued-expression-after-keyword/4
+                   "
+guard
+|1
+" "
+guard
+  |1
 ")
 
 

--- a/test/indentation-tests.el
+++ b/test/indentation-tests.el
@@ -2659,6 +2659,75 @@ try!
   |foo
 ")
 
+(check-indentation indents-conditional-compilation/1
+                   "
+{
+    #if a
+|a
+    #elseif a
+    a
+    #else
+    a
+    #endif
+}
+" "
+{
+    #if a
+    |a
+    #elseif a
+    a
+    #else
+    a
+    #endif
+}
+")
+
+(check-indentation indents-conditional-compilation/2
+                   "
+{
+    #if a
+    a
+|#elseif a
+    a
+    #else
+    a
+    #endif
+}
+" "
+{
+    #if a
+    a
+    |#elseif a
+    a
+    #else
+    a
+    #endif
+}
+")
+
+(check-indentation indents-conditional-compilation/3
+                   "
+{
+    #if a
+    a
+    #elseif a
+|a
+    #else
+    a
+    #endif
+}
+" "
+{
+    #if a
+    a
+    #elseif a
+    |a
+    #else
+    a
+    #endif
+}
+")
+
 
 
 (provide 'indentation-tests)


### PR DESCRIPTION
I have updated my old implementation #74 to support Swift 2.1 syntax #96 #125.

- Fixed indentation
- Fixed highlighting
- Supports playground comment syntax https://github.com/chrisbarrett/swift-mode/issues/96#issuecomment-137503789
- Supports fill-paragraph on comment
- Added extensions to Imenu
- Added some tests that current implementation fails (not only Swift 2.1 syntax but including Swift 1.0 syntax)

This patch also fixes #85 #59 #72 #35, like #117.

Tested with Emacs 24.5.2. All tests are passed with some cheating. I modified some tests a bit.

I don't expect you to merge this large complex patch. Please copy some parts not related to indentation if you like. I'm sorry for that you cannot cherry-pick simply because I have fixed both highlighting and indentation (or even worse, multiple issues) in same commit.  I should have splited commits into those related to indentation and others, and made separate PRs.